### PR TITLE
version up electron v0.34.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ cd <this repo>
 electron .
 ```
 
+### 実行ファイルの作り方
+
+```sh
+npm install electron-prebuilt -g
+git clone <this repo>
+cd <this repo>
+npm run-script pack
+
+# mac -> Make LGTM!-darwin-x64/Make LGTM!.app
+# win -> Make LGTM!-win32-x64/Make LGTM!.exe
+```
+
 ### SS (´ . .̫ . `)
 
 ![ss](doc/ss.png)

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "lgtm",
-  "version": "0.0.2",
-  "description": "",
+  "version": "0.0.3",
+  "description": "LGTM! の画像を簡単に作ってクリップボードにコピーする奴",
   "main": "main.js",
   "scripts": {
     "start": "electron .",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "pack": "electron-packager . \"Make LGTM!\" --platform=darwin,win32 --arch=x64 --version=0.30.4 --out=builds --icon=img/menubar-icon@2x.png && cd builds && zip -r \"Make LGTM for mac.zip\" \"Make LGTM!-darwin-x64\" && zip -r \"Make LGTM for Windows\" \"Make LGTM!-win32-x64\" && cd .."
+    "pack-mac": "electron-packager . \"Make LGTM!\" --platform=darwin --arch=x64 --version=0.34.1 --out=builds --icon=img/menubar-icon@2x.png",
+    "pack-win": "electron-packager . \"Make LGTM!\" --platform=win32 --arch=x64 --version=0.34.1 --out=builds --icon=img/menubar-icon@2x.png"
   },
   "author": "mironal",
   "license": "MIT",
@@ -14,9 +15,9 @@
     "react": "^0.13.3",
     "react-draggable": "^0.8.1",
     "temp": "^0.8.3",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "electron-prebuilt": "^0.31.0"
   },
   "devDependencies": {
-    "electron-prebuilt": "^0.31.0"
   }
 }


### PR DESCRIPTION
- ついでに win と mac のビルドスクリプトを分けた
- electron-prebuilt を dependencies にした
